### PR TITLE
Don't show issues in backlog that cannot be assigned to the selected sprint

### DIFF
--- a/assets/javascripts/scrumbler-backlog.js
+++ b/assets/javascripts/scrumbler-backlog.js
@@ -752,10 +752,9 @@ return Class.create({
 		}
 		
 		// don't show issues that can't be assigned to the selected sprint
-		issues.each(function(issue){
+		issues.each(function(issue, key){
 			if(issue.disabled){
-				var idx = issues.indexOf(issue);
-				if(idx!=-1){ issues.splice(idx, 1); }
+				delete issues[key];
 			}
 		});
 	}

--- a/assets/javascripts/scrumbler-backlog.js
+++ b/assets/javascripts/scrumbler-backlog.js
@@ -750,6 +750,14 @@ return Class.create({
 		}else{
 			issues.each(function(issue){ issue.disabled = true });
 		}
+		
+		// don't show issues that can't be assigned to the selected sprint
+		issues.each(function(issue){
+			if(issue.disabled){
+				var idx = issues.indexOf(issue);
+				if(idx!=-1){ issues.splice(idx, 1); }
+			}
+		});
 	}
 });
 })();


### PR DESCRIPTION
Currently the backlog shows issues that cannot be assigned to the selected sprint with a grey background.
A large backlog is much easier to read if these issues are just hidden.

References issue #37
